### PR TITLE
🚀 feat(category): Add slug and isActive to schema

### DIFF
--- a/src/common/interceptors/upload.interceptor.ts
+++ b/src/common/interceptors/upload.interceptor.ts
@@ -1,8 +1,22 @@
-import { FileInterceptor } from "@nestjs/platform-express";
+import { memoryStorage } from "multer";
+import { FileFieldsInterceptor, FileInterceptor } from "@nestjs/platform-express";
 import { multerStorage } from "../utils/multer.util";
+import { MulterField } from "@nestjs/platform-express/multer/interfaces/multer-options.interface";
 
 export const UploadFile = (fieldName:string, folderName:string = "images") => {
     return class UploadUtility extends FileInterceptor(fieldName, {
         storage: multerStorage(folderName)
+    }) {}
+}
+
+export const UploadFileS3 = (filedName:string) => {
+    return class UploadUtility extends FileInterceptor(filedName, {
+        storage: memoryStorage()
+    }) {}
+}
+
+export const UploadFileFieldsS3 = (uploadFields:MulterField[]) => {
+    return class UploadUtility extends FileFieldsInterceptor(uploadFields, {
+        storage: memoryStorage()
     }) {}
 }

--- a/src/modules/category/category.controller.ts
+++ b/src/modules/category/category.controller.ts
@@ -36,6 +36,12 @@ export class CategoryController {
     return this.categoryService.findOne(id);
   }
   
+  @Get("/:slug")
+  @SkipAuth()
+  findBySlug(@Param("slug") slug:string) {
+    return this.categoryService.findOneBySlug(slug);
+  }
+
   @Patch(':id')
   @CanAccess(Roles.Admin)
   update(@Param('id') id: string, @Body() updateCategoryDto: UpdateCategoryDto) {

--- a/src/modules/category/category.module.ts
+++ b/src/modules/category/category.module.ts
@@ -4,14 +4,14 @@ import { CategoryService } from './category.service';
 import { CategoryController } from './category.controller';
 import { AuthModule } from '../auth/auth.module';
 import { CategoryEntity } from './entities/category.entity';
+import { S3Service } from '../s3/s3.service';
 
 @Module({
   imports: [
     AuthModule,
-    TypeOrmModule,
     TypeOrmModule.forFeature([CategoryEntity])
   ],
   controllers: [CategoryController],
-  providers: [CategoryService],
+  providers: [CategoryService, S3Service],
 })
 export class CategoryModule {}

--- a/src/modules/category/category.service.ts
+++ b/src/modules/category/category.service.ts
@@ -15,7 +15,8 @@ export class CategoryService {
   ) {}
 
   async create(categoryDto: CategoryDto) {
-    let { title, priority, parentId } = categoryDto;
+    let { title, parentId, slug, isActive } = categoryDto;
+    
     title = await this.checkExistByTitle(title);
 
     // if check category parent existing
@@ -27,8 +28,8 @@ export class CategoryService {
     }
 
     const category = this.categoryRepository.create({
-      title, priority,
-      parent: parentCategory
+      title, slug,
+      isActive, parent: parentCategory
     });
 
     await this.categoryRepository.save(category);
@@ -54,6 +55,10 @@ export class CategoryService {
     }
   }
 
+  async findOneBySlug(slug:string) {
+    return await this.categoryRepository.findOneBy({ slug });
+  }
+
   async findOne(id: string) {
     const category = await this.categoryRepository.findOne({
       where: { id },
@@ -65,9 +70,10 @@ export class CategoryService {
 
   async update(id: string, updateCategoryDto: UpdateCategoryDto) {
     const category = await this.findOne(id);
-    const { title, priority } = updateCategoryDto;
+    const { title, isActive, slug } = updateCategoryDto;
     if (title) category.title = title;
-    if (priority) category.priority = priority;
+    if (slug) category.slug = slug;
+    if (isActive) category.isActive = isActive;
 
     await this.categoryRepository.save(category);
 

--- a/src/modules/category/dto/category.dto.ts
+++ b/src/modules/category/dto/category.dto.ts
@@ -3,8 +3,10 @@ import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 export class CategoryDto {
     @ApiProperty()
     title:string;
-    @ApiPropertyOptional()
-    priority:number;
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({ nullable: true })
+    slug:string;
+    @ApiProperty({ type: "boolean" })
+    isActive:boolean;
+    @ApiPropertyOptional({ nullable: true })
     parentId:string;
 }

--- a/src/modules/category/entities/category.entity.ts
+++ b/src/modules/category/entities/category.entity.ts
@@ -6,8 +6,10 @@ import { BaseEntity } from "src/common/abstracts/base.entity";
 export class CategoryEntity extends BaseEntity {
     @Column()
     title:string;
-    @Column({ nullable: true })
-    priority:number;
+    @Column()
+    slug:string;
+    @Column({ default: true })
+    isActive:boolean
     @ManyToOne(() => CategoryEntity, category => category.children, { nullable: true, onDelete: "CASCADE" })
     parent:CategoryEntity;
     @OneToMany(() => CategoryEntity, category => category.parent)


### PR DESCRIPTION
This PR updates the Category schema by adding two new fields:

✅ slug → A unique identifier for categories to be used in URLs.
✅ isActive → A boolean field to enable or disable categories.